### PR TITLE
Redirect the bsnes v115 documentation link to the bsnes homepage.

### DIFF
--- a/doc/bsnes/index.html
+++ b/doc/bsnes/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<meta http-equiv="refresh" content="0; url=//byuu.org/bsnes/" />


### PR DESCRIPTION
This link is not present in later versions of bsnes, but while bsnes v115 is the most popular version, it should lead somewhere.